### PR TITLE
Fix typo vllm inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pip install -r requirements.txt
 #### Model Inference
 ```bash
 cd FollowBench/
-python code/model_inference_vllm.py --model_path <model_name_or_path>
+python code/model_inference_vllm.py --model-path <model_name_or_path>
 ```
 
 #### LLM-based Evaluation


### PR DESCRIPTION
model_path --> model-path in the readme (only applies to vllm inference)